### PR TITLE
allow hyphens in YAML keys

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -128,7 +128,7 @@ function getIndentation(lineText) {
 
 // Helper function to extract a key from a line
 function getKeyFromLine(lineText) {
-    let keyMatch = lineText.match(/"([^"]+)"\s*:/) || lineText.match(/(\w+)\s*:/);
+    let keyMatch = lineText.match(/"([^"]+)"\s*:/) || lineText.match(/([\w-]+)\s*:/);
     return keyMatch ? keyMatch[1] : null;
 }
 


### PR DESCRIPTION
Updates the `getKeyFromLine` regex matchers to allow a hyphen to be used in key names since they are valid per the YAML spec.

Prior to this change, the following example would incorrectly output `foobar.foo.quaz` (silently dropping everything before the hyphen) whereas the correct key should have been `foobar.bar-foo.quaz`.

```yaml
foobar:
  bar-foo:
    quaz: "value"
```

I attempted to add unit tests for this however, it doesn't look like the test suite is up and running yet. Instead, here are some regex tests: https://regex101.com/r/CZ54cF/1 (clicking on the left hand navigation for "unit tests" will show the outputs and examples we care about here.